### PR TITLE
Install and build zhihu.models

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@ from setuptools import setup
 
 setup(
     name="zhihu",
-    packages=["zhihu"],
+    packages=[
+        "zhihu",
+        "zhihu.models"
+    ],
     include_package_data= True,
     install_requires = [
         "pytest-runner",


### PR DESCRIPTION
这个pr解决的问题：
使用pip install . 时，models内的模块不会被安装。

错误信息：
```
Python 3.6.0 (default, Dec 24 2016, 00:01:50) 
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import zhihu
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/site-packages/zhihu/__init__.py", line 3, in <module>
    from zhihu.models import answer
ModuleNotFoundError: No module named 'zhihu.models'
```